### PR TITLE
Fix BPMN graph creation for empty activities

### DIFF
--- a/app/converters/bpmn_converter.py
+++ b/app/converters/bpmn_converter.py
@@ -19,9 +19,7 @@ class BPMNConverter:
     def build_inductive_graph(data: InductiveBPMNData) -> BPMNGraph:
         """Create the BPMNGraph for an inductive miner."""
         if not data.filtered_events:
-            graph = BPMNGraph(data.filtered_events)
-            graph.add_edge("Start", "End", None)
-            return graph
+            return BPMNConverter._build_empty_graph(data)
 
         return BPMNGraph(
             data.process_tree,
@@ -29,3 +27,11 @@ class BPMNConverter:
             node_sizes=data.node_sizes,
             node_stats_map=data.node_stats_map,
         )
+
+    @staticmethod
+    def _build_empty_graph(data: InductiveBPMNData) -> BPMNGraph:
+        graph = BPMNGraph(data.filtered_events)
+        graph.add_start_node()
+        graph.add_end_node()
+        graph.add_edge("Start", "End", None)
+        return graph

--- a/tests/converters/bpmn_converter_test.py
+++ b/tests/converters/bpmn_converter_test.py
@@ -1,0 +1,27 @@
+import unittest
+
+from app.converters.bpmn_converter import BPMNConverter, InductiveBPMNData
+
+
+class BPMNConverterTest(unittest.TestCase):
+    def setUp(self):
+        self.bpmn_converter = BPMNConverter()
+
+    def test_build_inductive_graph_with_empty_filtered_events(self):
+        """Test that empty filtered events create a Start to End BPMN graph."""
+        empty_data = InductiveBPMNData(
+            process_tree=None,
+            filtered_events=set(),
+            filtered_appearance_freqs={},
+            node_sizes={},
+            node_stats_map={},
+        )
+        graph = self.bpmn_converter.build_inductive_graph(empty_data)
+
+        self.assertTrue(graph.contains_node("Start"))
+        self.assertTrue(graph.contains_node("End"))
+        self.assertTrue(graph.contains_edge("Start", "End"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What was changed
This PR fixes issue #20
When all activities are filtered out, the converter now creates an empty BPMN graph with Start and End nodes.

## Testing
- Tested manually using scenario from issue #20 
- Ran `python -m unittest discover -p "*test.py"`
 
