### PR TITLE
Add fixed graph layout filtering

### DIFF
--- a/app/graphs/visualization/base_graph.py
+++ b/app/graphs/visualization/base_graph.py
@@ -16,7 +16,8 @@ class Node:
         self,
         id: str | int,
         label: str = "",
-        data: dict[str, str | int | float] = None,
+        data: dict[str, str | int | float] | None = None,
+        attributes: dict[str, str | int | float] | None = None,
     ) -> None:
         """Initializes the Node object.
 
@@ -26,15 +27,20 @@ class Node:
             The id of the node.
         label : str, optional
             The label of the node. If not provided, the id is used as the label, by default "".
-        data : dict[str, str  |  int  |  float], optional
+        data : dict[str, str  |  int  |  float] | None, optional
             A dictionary of data for the node, by default None.
+        attributes : dict[str, str | int | float] | None, optional
+            Additional Graphviz attributes of the node, by default None.
         """
         self.id: str = str(id)
         if label:
             self.label: str = label
         else:
             self.label: str = str(id)
-        self.__data: dict[str, str | int | float] = data
+        self.__data: dict[str, str | int | float] | None = None
+        self.attributes: dict[str, str | int | float] | None = {}
+        self.set_data(data)
+        self.set_attributes(attributes)
 
     def get_label(self) -> str:
         """Returns the label of the node.
@@ -56,7 +62,20 @@ class Node:
         """
         return self.id
 
-    def get_data(self) -> dict[str, str | int | float]:
+    def set_data(self, data: dict[str, str | int | float] | None) -> None:
+        """Set the data stored in the node.
+
+        Parameters
+        ----------
+        data : dict[str, str  |  int  |  float]
+            The new node data.
+        """
+        if data is not None:
+            self.__data = data.copy()
+        else:
+            self.__data = None
+
+    def get_data(self) -> dict[str, str | int | float] | None:
         """Returns the data of the node.
 
         Returns
@@ -65,6 +84,29 @@ class Node:
             The data of the node.
         """
         return self.__data
+
+    def set_attributes(self, attributes: dict[str, str | int | float] | None) -> None:
+        """Set the Graphviz attributes of the node.
+
+        Parameters
+        ----------
+        attributes : dict[str, str  |  int  |  float] | None
+            New attributes of the node.
+        """
+        if attributes is not None:
+            self.attributes = attributes.copy()
+        else:
+            self.attributes = {}
+
+    def get_attributes(self) -> dict[str, str | int | float]:
+        """Returns the Graphviz attributes of the node.
+
+        Returns
+        -------
+        dict[str, str | int | float]
+            The attributes of the node.
+        """
+        return self.attributes
 
     def get_data_from_key(self, key: str) -> str | int | float | None:
         """Returns the value of the data corresponding to the key.
@@ -157,6 +199,7 @@ class BaseGraph:
         self.edges: dict[tuple[str, str], Edge] = {}
 
         self.graph = graphviz.Digraph(
+            strict=True,
             graph_attr={"fontname": "Montserrat"},
             node_attr={"fontname": "Montserrat"},
             edge_attr={"fontname": "Montserrat"},
@@ -171,6 +214,8 @@ class BaseGraph:
         # UI feature: optionally highlight Happy Path
         # Separate state so one can toggle highlighting without re-mining the whole model.
         self._highlighted_node_ids: set[str] = set()
+        self._invisible_node_ids: set[str] = set()
+        self._invisible_edge_ids: set[tuple[str, str]] = set()
         self._highlight_fillcolor = "#FFE08A"
         self._highlight_bordercolor = "#D97B00"
 
@@ -200,6 +245,56 @@ class BaseGraph:
                     break
 
         self._highlighted_node_ids = highlighted
+
+    def set_invisible_nodes(self, current_node_ids: list[str]) -> None:
+        """Mark nodes missing from the current graph as invisible.
+
+        Parameters
+        ----------
+        current_node_ids : list[str]
+            List of all node ids present in current filtered graph.
+        """
+        self._invisible_node_ids = set()
+        for node in self.get_nodes():
+            if node.get_id() not in current_node_ids:
+                self._invisible_node_ids.add(node.get_id())
+
+    def update_visible_nodes(self, current_nodes: list[Node]) -> None:
+        """Update labels, data and visual attributes of nodes that exist in both graphs.
+
+        Parameters
+        ----------
+        current_nodes : list[Node]
+            The filtered nodes of current graph.
+        """
+        for node in current_nodes:
+            node_id = node.get_id()
+            if not self.contains_node(node_id):
+                continue
+
+            fixed_node = self.get_node(node_id)
+            fixed_node.label = node.get_label()
+            fixed_node.set_data(node.get_data())
+            fixed_node.set_attributes(node.get_attributes())
+
+    def set_invisible_edges(self, edges: list[Edge]) -> None:
+        """Mark edges missing from current graph as invisible.
+
+        Parameters
+        ----------
+        edges : list[Edge]
+            List of all edges that are present in current filtered graph.
+        """
+        self._invisible_edge_ids = set()
+
+        edge_ids = {(edge.source, edge.destination) for edge in edges}
+        for source_id, target_id in self.edges.keys():
+            if (
+                (source_id, target_id) not in edge_ids
+                or source_id in self._invisible_node_ids
+                or target_id in self._invisible_node_ids
+            ):
+                self._invisible_edge_ids.add((source_id, target_id))
 
     def add_node(
         self,
@@ -235,16 +330,16 @@ class BaseGraph:
         if self.contains_node(id):
             raise DuplicateNodeException(id)
 
-        node = Node(id, label, data)
-        self.nodes[node.get_id()] = node
-
         if "filled" not in node_attributes.get("style", ""):
             if "style" in node_attributes:
                 node_attributes["style"] += ", filled"
             else:
                 node_attributes["style"] = "filled"
 
-        graphviz_id = self.substitiute_colons(node.get_id())
+        node = Node(id, label, data, attributes=node_attributes.copy())
+        self.nodes[node.get_id()] = node
+
+        graphviz_id = self.substitute_colons(node.get_id())
         self.graph.node(graphviz_id, node.get_label(), **node_attributes)
 
     def add_start_node(self, id: str = "Start") -> None:
@@ -347,7 +442,7 @@ class BaseGraph:
         Parameters
         ----------
         source_id : str | int
-            soruce node id
+            source node id
         target_id : str | int
             target node id
         weight : float, optional
@@ -379,8 +474,8 @@ class BaseGraph:
         else:
             label = str(weight)
 
-        graphviz_source_id = self.substitiute_colons(edge.source)
-        graphviz_target_id = self.substitiute_colons(edge.destination)
+        graphviz_source_id = self.substitute_colons(edge.source)
+        graphviz_target_id = self.substitute_colons(edge.destination)
 
         self.graph.edge(
             graphviz_source_id,
@@ -512,33 +607,96 @@ class BaseGraph:
             The graphviz string of the graph.
         """
         source = self.graph.source
-        if not self._highlighted_node_ids:
-            return source
+        lines = []
 
-        # Inject "override" node statements before the closing brace.
-        # Graphviz merges attributes for the same node id -> safely updates styling.
-        highlight_lines = []
-        for node_id in sorted(self._highlighted_node_ids):
-            graphviz_node_id = self.substitiute_colons(str(node_id))
-
-            # Quote/escape the id so the injected DOT stays valid even if node ids contain special characters.
-            escaped_node_id = graphviz_node_id.replace("\\", "\\\\").replace('"', '\\"')
-            highlight_lines.append(
-                f'\t"{escaped_node_id}" '
-                f'[fillcolor="{self._highlight_fillcolor}", color="{self._highlight_bordercolor}", penwidth="2"];'
-            )
+        lines.extend(self._make_invisible_edge_lines())
+        lines.extend(self._make_invisible_node_lines())
+        lines.extend(self._make_highlighted_node_lines())
 
         closing_brace_index = source.rfind("}")
         if closing_brace_index == -1:
-            return source + "\n" + "\n".join(highlight_lines)
+            return source + "\n" + "\n".join(lines)
 
         return (
             source[:closing_brace_index]
             + "\n"
-            + "\n".join(highlight_lines)
+            + "\n".join(lines)
             + "\n"
             + source[closing_brace_index:]
         )
+
+    def _get_escaped_node_id(self, node_id: str) -> str:
+        """Escape a Graphviz node id.
+
+        Parameters
+        ----------
+        node_id : str
+            The node id to quote/escape.
+
+        Returns
+        -------
+        str
+            The escaped Graphviz node id.
+        """
+        graphviz_node_id = self.substitute_colons(str(node_id))
+        # Quote/escape the id so the injected DOT stays valid even if node ids contain special characters.
+        escaped_node_id = graphviz_node_id.replace("\\", "\\\\").replace('"', '\\"')
+        return escaped_node_id
+
+    def _make_invisible_edge_lines(self) -> list[str]:
+        """Create Graphviz lines for edges that are set to invisible.
+
+        Returns
+        -------
+        list[str]
+           Graphviz edges set to invisible.
+        """
+        lines = []
+        for source_id, target_id in self._invisible_edge_ids:
+            escaped_source_id = self._get_escaped_node_id(source_id)
+            escaped_target_id = self._get_escaped_node_id(target_id)
+            lines.append(
+                f'\t"{escaped_source_id}" -> "{escaped_target_id}" [style="invis"];'
+            )
+
+        return lines
+
+    def _make_invisible_node_lines(self) -> list[str]:
+        """Create Graphviz lines for nodes that should be set to invisible.
+
+        Returns
+        -------
+        list[str]
+            Graphviz nodes set to invisible.
+        """
+        lines = []
+        if self._invisible_node_ids:
+            for node_id in self._invisible_node_ids:
+                escaped_node_id = self._get_escaped_node_id(node_id)
+                lines.append(f'\t"{escaped_node_id}" [style="invis"];')
+
+        return lines
+
+    def _make_highlighted_node_lines(self) -> list[str]:
+        """Create Graphviz lines for highlighted nodes in fixed graph.
+
+        Returns
+        -------
+        list[str]
+            Graphviz highlighted nodes.
+        """
+        lines = []
+        if self._highlighted_node_ids:
+            # Inject "override" node statements before the closing brace.
+            # Graphviz merges attributes for the same node id -> safely updates styling.
+            for node_id in sorted(self._highlighted_node_ids):
+                escaped_node_id = self._get_escaped_node_id(node_id)
+                lines.append(
+                    f'\t"{escaped_node_id}" '
+                    f'[fillcolor="{self._highlight_fillcolor}", color="{self._highlight_bordercolor}", penwidth="2"];'
+                )
+
+        return lines
 
     def get_graphviz_graph(self) -> graphviz.Digraph:
         """Returns the graphviz graph of the graph.
@@ -599,7 +757,7 @@ class BaseGraph:
                 description += f"\n**{key}:** {value}"
         return name, description
 
-    def substitiute_colons(self, string: str) -> str:
+    def substitute_colons(self, string: str) -> str:
         """Replaces the colon with the colon substitute in the string.
 
         Parameters

--- a/app/ui/base_algorithm_ui/base_algorithm_controller.py
+++ b/app/ui/base_algorithm_ui/base_algorithm_controller.py
@@ -4,6 +4,7 @@ import streamlit as st
 from app.components.buttons import to_home
 from app.exceptions.graph_exceptions import InvalidNodeNameException, GraphException
 from app.exceptions.type_exceptions import TypeIsNoneException
+from app.graphs.visualization.base_graph import BaseGraph
 from app.logger import get_logger
 from app.transformations.dataframe_transformations import DataframeTransformations
 from app.ui.base_ui.base_controller import BaseController
@@ -13,7 +14,11 @@ class BaseAlgorithmController(BaseController, ABC):
     """Base class for the algorithm controllers. It provides the basic methods for the algorithm controllers."""
 
     def __init__(
-        self, views=None, mining_model_class=None, dataframe_transformations=None
+        self,
+        views=None,
+        mining_model_class=None,
+        dataframe_transformations=None,
+        supports_fixed_graph_layout: bool = False,
     ):
         """Initializes the controller for the algorithm views.
 
@@ -25,11 +30,14 @@ class BaseAlgorithmController(BaseController, ABC):
             The class of the mining model, by default None
         dataframe_transformations : DataframeTransformations, optional
             The class for the dataframe transformations. If None is passed, a new instance is created, by default None
+        supports_fixed_graph_layout : bool
+            If True, the fixed graph layout is available, by default False.
         """
         self.spm_threshold = None
         self.node_freq_threshold_normalized = None
         self.node_freq_threshold_absolute = None
         self.logger = get_logger("BaseAlgorithmController")
+        self.supports_fixed_graph_layout = supports_fixed_graph_layout
 
         self.mining_model = None
 
@@ -227,6 +235,7 @@ class BaseAlgorithmController(BaseController, ABC):
         self.process_algorithm_parameters()
         view.display_back_button()
         view.display_export_button(disabled=True)
+
         if self.have_parameters_changed() or self.mining_model.get_graph() is None:
             try:
                 view.display_loading_spinner("Mining...", self.perform_mining)
@@ -249,9 +258,18 @@ class BaseAlgorithmController(BaseController, ABC):
                 st.warning(
                     "Do not change the parameters while mining. This will cause an error. Wait until the mining is finished."
                 )
-        view.display_sidebar(self.get_sidebar_values())
 
         graph = self.mining_model.get_graph()
+        self._disable_fixed_layout_if_graph_changed(graph)
+
+        view.display_sidebar(
+            self.get_sidebar_values(),
+            supports_fixed_graph_layout=self.supports_fixed_graph_layout,
+        )
+
+        new_graph = self._apply_fixed_graph_position(graph)
+        if new_graph is not None:
+            graph = new_graph
         self._apply_happy_path_highlighting(graph)
         view.display_graph(graph)
         view.display_export_button(disabled=False)
@@ -272,3 +290,104 @@ class BaseAlgorithmController(BaseController, ABC):
             happy_path_events = self.mining_model.get_happy_path_events(variant_index)
 
         graph.highlight_happy_path(happy_path_events)
+
+    def _apply_fixed_graph_position(self, graph: BaseGraph) -> BaseGraph | None:
+        """Apply fixed graph position handling to the current graph.
+
+        Parameters
+        ----------
+        graph : BaseGraph
+            The currently generated graph after applying filtering.
+
+        Returns
+        -------
+        BaseGraph | None
+            If fixed layout is enabled and graph already is stored, returns the graph
+            with updated visibility information. Otherwirse, None.
+        """
+        if not self.supports_fixed_graph_layout:
+            st.session_state.graph_fixed_position = None
+            return None
+
+        if graph is None:
+            return None
+
+        if not st.session_state.get("fix_graph_layout", False):
+            st.session_state.graph_fixed_position = None
+            return None
+
+        if not st.session_state.get("graph_fixed_position"):
+            st.session_state.graph_fixed_position = graph
+            return None
+
+        fixed_graph = st.session_state.get("graph_fixed_position")
+        fixed_graph.set_invisible_nodes(graph.get_node_ids())
+        fixed_graph.update_visible_nodes(graph.get_nodes())
+        fixed_graph.set_invisible_edges(graph.get_edges())
+        return fixed_graph
+
+    def _disable_fixed_layout_if_graph_changed(self, graph: BaseGraph) -> None:
+        """Disable fixed graph layout if the current graph structure has changed.
+
+        Parameters
+        ----------
+        graph : BaseGraph
+            The newly generated graph.
+        """
+        if graph is None:
+            return
+        if not st.session_state.get("fix_graph_layout", False):
+            return
+
+        fixed_graph = st.session_state.get("graph_fixed_position")
+        if fixed_graph is None:
+            return
+        if self._has_current_graph_new_element(fixed_graph, graph):
+            self._disable_fixed_layout()
+
+    def _has_current_graph_new_element(
+        self, fixed_graph: BaseGraph, current_graph: BaseGraph
+    ) -> bool:
+        """Compare edges and nodes of fixed graph and current graph.
+
+        Parameters
+        ----------
+        fixed_graph : BaseGraph
+            The saved graph when fixed layout was enabled.
+        current_graph : BaseGraph
+            The newly generated graph with which fixed graph will be compared.
+
+        Returns
+        -------
+        bool
+            Returns True when current graph has edge or node which are not present
+            in fixed graph, otherwise False.
+        """
+        current_edge_ids = {
+            (edge.source, edge.destination) for edge in current_graph.get_edges()
+        }
+        fixed_edge_ids = {
+            (edge.source, edge.destination) for edge in fixed_graph.get_edges()
+        }
+
+        current_node_ids = {node.get_id() for node in current_graph.get_nodes()}
+        fixed_node_ids = {node.get_id() for node in fixed_graph.get_nodes()}
+
+        for source_id, target_id in current_edge_ids:
+            if (source_id, target_id) not in fixed_edge_ids:
+                return True
+
+        for node_id in current_node_ids:
+            if node_id not in fixed_node_ids:
+                return True
+
+        return False
+
+    def _disable_fixed_layout(self) -> None:
+        """Clear stored layout state and disable the fix layout toggle and show a warning that layout was disabled."""
+        st.session_state.fix_graph_layout = False
+        st.session_state.graph_fixed_position = None
+        st.warning(
+            "Fixed graph layout was disabled because the graph structure changed and the graph had to be regenerated."
+        )
+        return None

--- a/app/ui/base_algorithm_ui/base_algorithm_view.py
+++ b/app/ui/base_algorithm_ui/base_algorithm_view.py
@@ -31,7 +31,9 @@ class BaseAlgorithmView(BaseView):
         with export_button_column:
             self.export_button_container = st.empty()
 
-    def render_sidebar(self, sidebar_values: dict[str, any]) -> None:
+    def render_sidebar(
+        self, sidebar_values: dict[str, any], supports_fixed_graph_layout: bool = False
+    ) -> None:
         """Renders the sidebar for the algorithm views.
         Displays shared filters and calls extension hooks for node and edge filtering.
 
@@ -40,6 +42,8 @@ class BaseAlgorithmView(BaseView):
         sidebar_values : dict[str, any]
             A dictionary containing the values for the sidebar elements. The keys of the dictionary
             are equal to the keys of the sliders and define the slider bounds.
+        supports_fixed_graph_layout : bool, optional
+            If True, the fixed graph layout is available, by default False.
         """
         st.write("### **Log Filtering**")
 
@@ -109,22 +113,39 @@ class BaseAlgorithmView(BaseView):
                     trace_str = " -> ".join(str(step) for step in trace)
                     st.markdown(f"**Current Variant:** {trace_str}")
 
+        if supports_fixed_graph_layout:
+            st.write("### **Graph Layout**")
+            st.toggle(
+                "Fix Graph Layout",
+                key="fix_graph_layout",
+                value=st.session_state.get("fix_graph_layout", False),
+                help="Fixes the graph in current position.",
+            )
+        else:
+            st.session_state.fix_graph_layout = False
+
     def render_log_filter_extensions(self, sidebar_values: dict[str, any]) -> None:
         """Renders additional node filtering controls.
         Can be overridden by subclasses to add more node filters.
         """
         pass
 
-    def display_sidebar(self, sidebar_values: dict[str, any]) -> None:
+    def display_sidebar(
+        self, sidebar_values: dict[str, any], supports_fixed_graph_layout: bool = False
+    ) -> None:
         """Displays the sidebar for the algorithm views. The methode calls the render_sidebar method of the subclass.
 
         Parameters
         ----------
         sidebar_values : dict[str, any]
             A dictionary containing the values for the sidebar elements. The keys of the dictionary are equal to the keys of the sliders.
+        supports_fixed_graph_layout : bool, optional
+            If true, the fixed graph layout is enabled, be default false.
         """
         with st.sidebar:
-            self.render_sidebar(sidebar_values)
+            self.render_sidebar(
+                sidebar_values, supports_fixed_graph_layout=supports_fixed_graph_layout
+            )
 
     def display_back_button(self) -> None:
         """Displays the back button. The button navigates back to the home page."""

--- a/app/ui/fuzzy_miner_ui/fuzzy_miner_controller.py
+++ b/app/ui/fuzzy_miner_ui/fuzzy_miner_controller.py
@@ -36,7 +36,12 @@ class FuzzyMinerController(BaseAlgorithmController):
         if mining_model_class is None:
             mining_model_class = FuzzyMining
 
-        super().__init__(views, mining_model_class, dataframe_transformations)
+        super().__init__(
+            views,
+            mining_model_class,
+            dataframe_transformations,
+            supports_fixed_graph_layout=True,
+        )
 
     def get_page_title(self) -> str:
         """Returns the page title.

--- a/app/ui/heuristic_miner_ui/heuristic_miner_controller.py
+++ b/app/ui/heuristic_miner_ui/heuristic_miner_controller.py
@@ -32,7 +32,12 @@ class HeuristicMinerController(BaseAlgorithmController):
         if mining_model_class is None:
             mining_model_class = HeuristicMining
 
-        super().__init__(views, mining_model_class, dataframe_transformations)
+        super().__init__(
+            views,
+            mining_model_class,
+            dataframe_transformations,
+            supports_fixed_graph_layout=True,
+        )
 
     def get_page_title(self) -> str:
         """Returns the page title.

--- a/tests/graphs/visualization/base_graph_test.py
+++ b/tests/graphs/visualization/base_graph_test.py
@@ -248,6 +248,49 @@ class TestBaseGraph(unittest.TestCase):
         self.assertEqual(edge.source, "node:1")
         self.assertEqual(edge.destination, "node2")
 
+    def test_set_invisible_edges_applies_invisible_style_to_missing_edges(self):
+        fixed_graph = BaseGraph()
+        fixed_graph.add_node("node1")
+        fixed_graph.add_node("node2")
+        fixed_graph.add_node("node3")
+        fixed_graph.add_edge("node1", "node2", 3)
+        fixed_graph.add_edge("node1", "node3", 4)
+
+        current_graph = BaseGraph()
+        current_graph.add_node("node1")
+        current_graph.add_node("node2")
+        current_graph.add_node("node3")
+        current_graph.add_edge("node1", "node2", 3)
+
+        fixed_graph.set_invisible_edges(current_graph.get_edges())
+        graphviz_string = fixed_graph.get_graphviz_string()
+
+        self.assertIn("node1 -> node2 [label=3]", graphviz_string)
+        self.assertIn("node1 -> node3 [label=4]", graphviz_string)
+        self.assertIn('"node1" -> "node3" [style="invis"];', graphviz_string)
+
+    def test_set_invisible_edges_handles_quoted_edge_ids(self):
+        fixed_graph = BaseGraph()
+        fixed_graph.add_node("Start")
+        fixed_graph.add_node("task 1")
+        fixed_graph.add_node("End")
+        fixed_graph.add_edge("Start", "task 1", None)
+        fixed_graph.add_edge("task 1", "End", None)
+
+        current_graph = BaseGraph()
+        current_graph.add_node("Start")
+        current_graph.add_node("End")
+
+        fixed_graph.set_invisible_nodes(current_graph.get_node_ids())
+        fixed_graph.set_invisible_edges(current_graph.get_edges())
+        graphviz_string = fixed_graph.get_graphviz_string()
+
+        self.assertIn('Start -> "task 1" [label=""]', graphviz_string)
+        self.assertIn('"task 1" -> End [label=""]', graphviz_string)
+        self.assertIn('"Start" -> "task 1" [style="invis"];', graphviz_string)
+        self.assertIn('"task 1" -> "End" [style="invis"];', graphviz_string)
+        self.assertIn('"task 1" [style="invis"];', graphviz_string)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description
This PR adds a fixed graph layout option for filtering mention in Issue #8. When enabled, the first graph is kept as a reference, while nodes and edges that disappear after filtering are rendered invisibly to preserve that layout.
The newly added nodes are also handled for example Fuzzy Miner clusters.

### Notes
- The layout can still slightly shift when new nodes or edges are added.
- Fixed graph layout doesn't work for Genetic Mining, because it generates new model every time it runs.

### Testing
- Tested manually with sample files from directory.
- Tests were added for invisible nodes/edges, missing nodes/edges, cluster attributes and different source patterns.